### PR TITLE
Remove schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,9 +298,13 @@ Able Health's customers entrust us with a significant amount of protected health
 
 ## Team meetings :clipboard:
 
-* Monthly business update
-
-* Quarterly feedback
+* Daily Engineering standup (Engineering team)
+* Daily Business standup (Product, Engineering, Business)
+* Alternating, biweekly retrospectives:
+  * Product Team retro (everyone who works on product)
+  * Full Team retro (All Able staff)
+* Monthly business update (All Able staff)
+* Quarterly feedback (All Able staff)
 
 ## Availability etiquette :vertical_traffic_light:
 

--- a/README.md
+++ b/README.md
@@ -296,18 +296,6 @@ While we each bring a different perspective and set of expertise to customer int
 
 Able Health's customers entrust us with a significant amount of protected health information (PHI). As such, we take great care to ensure the security and privacy of potentially sensitive information. All team members receive HIPAA training and may refer to our HIPAA policies and procedures at any time for further details.
 
-## Team meetings :clipboard:
-
-* Product standup at 9:30am every day
-
-* Business standup at 10am every day
-
-* Retro Fridays at 1 pm
-
-* Monthly business update
-
-* Quarterly feedback
-
 ## Availability etiquette :vertical_traffic_light:
 
 * You should be generally available during PST 10am - 6pm. 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,12 @@ While we each bring a different perspective and set of expertise to customer int
 
 Able Health's customers entrust us with a significant amount of protected health information (PHI). As such, we take great care to ensure the security and privacy of potentially sensitive information. All team members receive HIPAA training and may refer to our HIPAA policies and procedures at any time for further details.
 
+## Team meetings :clipboard:
+
+* Monthly business update
+
+* Quarterly feedback
+
 ## Availability etiquette :vertical_traffic_light:
 
 * You should be generally available during PST 10am - 6pm. 


### PR DESCRIPTION
Removed the agile iteration events from the team meetings as it's no longer current and are variable, depending on the day. For example, [on Thursdays the engineering standup time depends on whether there is Product Retro or not](https://docs.google.com/document/d/1Z2fUoAlqHodJXf7USEUGKYVUtpKZBzqJ5YPlYaQuJJE/edit#).
